### PR TITLE
Replace privileged mode with RDMA device plugin for unprivileged NCCL tests

### DIFF
--- a/kubernetes/nccl_tests.yaml
+++ b/kubernetes/nccl_tests.yaml
@@ -19,6 +19,14 @@ spec:
                 - --allow-run-as-root
                 - -np
                 - "64"
+                - -npernode
+                - "8"
+                - --bind-to
+                - none
+                - -x
+                - NCCL_DEBUG=INFO
+                - -x
+                - LD_LIBRARY_PATH
                 - ./build/all_reduce_perf
                 - -b
                 - 512M
@@ -39,10 +47,15 @@ spec:
               resources:
                 limits:
                   nvidia.com/gpu: 8
+                  rdma/hca_shared_devices_a: 1
                   cpu: 64
                   memory: 512Gi
+                requests:
+                  nvidia.com/gpu: 8
+                  rdma/hca_shared_devices_a: 1
               securityContext:
-                privileged: true
+                capabilities:
+                  add: ["IPC_LOCK"]
               volumeMounts:
                 - mountPath: /dev/shm
                   name: dshm


### PR DESCRIPTION
## Summary

Removes `privileged: true` from the NCCL test worker pods and replaces it with the RDMA shared device plugin approach for unprivileged InfiniBand access.

## Changes

### Worker pods
- **Removed** `privileged: true` from `securityContext`
- **Added** `IPC_LOCK` capability — required for RDMA memory registration (`ibv_reg_mr()` calls `mlock()` internally)
- **Added** `rdma/hca_shared_devices_a: 1` resource request — the [k8s-rdma-shared-dev-plugin](https://github.com/Mellanox/k8s-rdma-shared-dev-plugin) injects `/dev/infiniband/*` devices filtered to InfiniBand-only (excludes Ethernet NICs)
- **Added** explicit `requests` for GPU to match `limits`

### Launcher (mpirun args)
- **Removed** hardcoded `NCCL_IB_HCA`, `NCCL_NET`, `NCCL_NET_GDR_LEVEL`, `UCX_TLS`, `UCX_NET_DEVICES` — the RDMA device plugin handles IB device filtering via `linkTypes: ["infiniband"]`
- **Added** `-npernode 8` and `--bind-to none` for proper MPI process binding
- **Added** `-x NCCL_DEBUG=INFO` for transport verification logging
- **Added** `-x LD_LIBRARY_PATH` to pass library paths to workers

## Prerequisites

The `k8s-rdma-shared-dev-plugin` DaemonSet and ConfigMap must be deployed on the target cluster for `rdma/hca_shared_devices_a` resources to be available. This plugin can be deployed either:
- **Standalone** — as a simple DaemonSet + ConfigMap in `kube-system`
- **Via NVIDIA Network Operator** — as a managed component in a `NicClusterPolicy` CR (uses the same plugin under the hood, same resource name)

## Validated ✅

Tested on the slurm-team cluster (g307, H100 node) with an unprivileged validation pod:

| Check | Result |
|-------|--------|
| Pod starts without `privileged: true` | ✅ |
| `/dev/infiniband` devices injected by RDMA plugin | ✅ 8 IB HCAs (`uverbs0,3,4,5,6,9,10,11`) |
| `ibv_devinfo` shows active IB ports | ✅ All `PORT_ACTIVE`, `link_layer: InfiniBand` |
| NCCL all_reduce_perf runs | ✅ 232 GB/s avg bus bandwidth (2-GPU NVLink) |
| GPUDirect RDMA enabled | ✅ `GDR 1` in NCCL transport logs |
| DMA-BUF active (no `nvidia_peermem` needed) | ✅ Kernel 5.12+ / driver 515+ |

```
Connected all rings, use ring PXN 0 GDR 1
# Avg bus bandwidth    : 232.315
```

> **Note:** Full multi-node inter-node RDMA test (`NET/IB/GDRDMA`) pending — requires both GPU nodes to be free simultaneously.