### PR TITLE
feat(ib): Add InfiniBand isolation test for pure IB fabric benchmarking

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -94,3 +94,15 @@ This will start the NCCL all_reduce_perf benchmark across the configured GPU wor
 Note: The launcher pod may enter a CrashLoopBackOff state until all worker pods are up and running. 
 
 For debugging add the flag `-x NCCL_DEBUG=INFO` to the MPI command.
+
+## InfiniBand Isolation Test
+
+To measure pure InfiniBand fabric performance (bypassing NVLink and shared memory), use the IB-only test:
+
+```bash
+kubectl apply -f kubernetes/nccl_tests_ib_only.yaml
+```
+
+This test sets `NCCL_P2P_DISABLE=1` and `NCCL_SHM_DISABLE=1` to force all GPU communication through the IB network. On NDR400 HCAs, expect ~49 GB/s bus bandwidth per GPU at large message sizes.
+
+Compare results against the standard test to isolate whether performance issues originate from the IB fabric or intra-node transports (NVLink/SHM).

--- a/kubernetes/nccl_tests_ib_only.yaml
+++ b/kubernetes/nccl_tests_ib_only.yaml
@@ -1,0 +1,86 @@
+# NCCL InfiniBand Isolation Test
+# Forces ALL traffic through InfiniBand by disabling NVLink P2P and shared memory.
+# Useful for verifying IB fabric health independent of intra-node transports.
+#
+# Expected: ~49 GB/s busbw per GPU on NDR400 HCAs
+#
+# Usage:
+#   1. Update -np (TOTAL_GPUS = replicas * 8) and replicas to match your cluster
+#   2. kubectl apply -f nccl_tests_ib_only.yaml
+#   3. kubectl logs -f <launcher-pod>
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: nccl-test-ib-only
+spec:
+  runPolicy:
+    cleanPodPolicy: Running
+  slotsPerWorker: 8
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: mpi-launcher
+              image: ghcr.io/voltagepark/nccl-tests:cuda12.4.1-ubuntu22.04-ssh-server
+              args:
+                - mpirun
+                - --allow-run-as-root
+                - -np
+                - "64"
+                - -npernode
+                - "8"
+                - --bind-to
+                - none
+                - -x
+                - NCCL_DEBUG=INFO
+                - -x
+                - LD_LIBRARY_PATH
+                - -x
+                - NCCL_IB_HCA=mlx5
+                - -x
+                - NCCL_P2P_DISABLE=1
+                - -x
+                - NCCL_SHM_DISABLE=1
+                - -x
+                - NCCL_IB_DISABLE=0
+                - -x
+                - NCCL_NET_GDR_LEVEL=5
+                - ./build/all_reduce_perf
+                - -b
+                - 512M
+                - -e
+                - 8G
+                - -f
+                - "2"
+                - -g
+                - "1"
+    Worker:
+      replicas: 8
+      template:
+        spec:
+          runtimeClassName: nvidia
+          containers:
+            - name: mpi-worker
+              image: ghcr.io/voltagepark/nccl-tests:cuda12.4.1-ubuntu22.04-ssh-server
+              resources:
+                limits:
+                  nvidia.com/gpu: 8
+                  rdma/hca_shared_devices_a: 1
+                  cpu: 64
+                  memory: 512Gi
+                requests:
+                  nvidia.com/gpu: 8
+                  rdma/hca_shared_devices_a: 1
+              securityContext:
+                capabilities:
+                  add: ["IPC_LOCK"]
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: dshm
+          volumes:
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 256Gi


### PR DESCRIPTION
## Summary
- Adds `kubernetes/nccl_tests_ib_only.yaml` — an MPIJob that isolates InfiniBand by disabling NVLink P2P and shared memory transports
- Forces all GPU communication through IB fabric with `NCCL_NET_GDR_LEVEL=5` for maximum GDR aggressiveness
- Updates Kubernetes README with usage instructions

## Test plan
- [ ] Apply YAML on a cluster with IB-connected GPU nodes
- [ ] Verify ~49 GB/s busbw per GPU on NDR400 HCAs
- [ ] Compare against standard `nccl_tests.yaml` to confirm NVLink contribution

Made with [Cursor](https://cursor.com)